### PR TITLE
support iOS fetch failure while offline

### DIFF
--- a/src/rexxarFetch.js
+++ b/src/rexxarFetch.js
@@ -92,6 +92,9 @@ function resolveResponse(response) {
 
     });
   } else {
+    if (response.status === 999) {
+      throw new TypeError('Network request failed');
+    }
     return response;
   }
 


### PR DESCRIPTION
iOS断网情况下，客户端返回了一个无法解析的Error类型，rexxar中fetch报错Type error。

解决：iOS返回一个特定status code的response，约定为 无网络 等客户端错误。
https://github.com/douban/rexxar-ios/blob/master/Rexxar/Core/RXRNSURLProtocol.m#L160
